### PR TITLE
Add sms_text_message to $activityParams

### DIFF
--- a/api/v3/Sms/Send.php
+++ b/api/v3/Sms/Send.php
@@ -67,6 +67,7 @@ function civicrm_api3_sms_send($params) {
 
     $activityParams['html_message'] = $messageTemplates->msg_html;
     $activityParams['text_message'] = $messageTemplates->msg_text;
+    $activityParams['sms_text_message'] = $messageTemplates->msg_text;
     $activityParams['activity_subject'] = $messageTemplates->msg_subject;
     $smsParams['provider_id'] = $params['provider_id'];
 


### PR DESCRIPTION
Civi appears to have renamed the text field in civicrm/civicrm-core@1b7a39f5
Leave old fields for backwards compatability.
