### PR TITLE
Closes #8: Add an optional SMS sender to the SMS Civirule

### DIFF
--- a/CRM/Smsapi/CivirulesAction.php
+++ b/CRM/Smsapi/CivirulesAction.php
@@ -84,16 +84,18 @@ class CRM_Smsapi_CivirulesAction extends CRM_CivirulesActions_Generic_Api {
       $providerInfo = CRM_SMS_BAO_Provider::getProviderInfo($params['provider_id']);
       $providerName = $providerInfo['title'];
     }
+    $senderName = Civi\Api4\Contact::get(FALSE)->addSelect('display_name')->addWhere('id', '=', $params['from_contact_id'])->execute()->first()['display_name'];
 
     $to = ts('the contact');
     if (!empty($params['alternative_receiver_phone_number'])) {
       $to = $params['alternative_receiver_phone_number'];
     }
 
-    return ts('Send SMS with provider "%1" with template "%2" to %3', array(
+    return ts('Send SMS with provider "%1" with template "%2" to %3 as sender %4', array(
         1=>$providerName,
         2=>$template,
-        3=>$to
+        3=>$to,
+        4 => $senderName,
     ));
   }
 }

--- a/CRM/Smsapi/Form/CivirulesAction.php
+++ b/CRM/Smsapi/Form/CivirulesAction.php
@@ -84,6 +84,7 @@ class CRM_Smsapi_Form_CivirulesAction extends CRM_Core_Form {
     $this->add('hidden', 'rule_action_id');
     $this->add('select', 'template_id', ts('Message template'), $this->getMessageTemplates(), true);
     $this->add('select', 'provider_id', ts('SMS Provider'), $this->getSmsProviders(), true);
+    $this->addEntityRef('from_contact_id', ts('Message Sender'));
     $this->add('checkbox','alternative_receiver', ts('Send to alternative phone number'));
     $this->add('text', 'alternative_receiver_phone_number', ts('Send to'));
 
@@ -111,6 +112,7 @@ class CRM_Smsapi_Form_CivirulesAction extends CRM_Core_Form {
     if (!empty($data['template_id'])) {
       $defaultValues['template_id'] = $data['template_id'];
     }
+    $defaultValues['from_contact_id'] = $data['from_contact_id'] ?? NULL;
     if (!empty($data['alternative_receiver_phone_number'])) {
       $defaultValues['alternative_receiver_phone_number'] = $data['alternative_receiver_phone_number'];
       $defaultValues['alternative_receiver'] = true;
@@ -126,6 +128,7 @@ class CRM_Smsapi_Form_CivirulesAction extends CRM_Core_Form {
   public function postProcess() {
     $data['provider_id'] = $this->_submitValues['provider_id'];
     $data['template_id'] = $this->_submitValues['template_id'];
+    $data['from_contact_id'] = $this->_submitValues['from_contact_id'] ?? CRM_Core_Session::getLoggedInContactID() ?? NULL;
     $data['alternative_receiver_phone_number'] = '';
     if (!empty($this->_submitValues['alternative_receiver_phone_number'])) {
       $data['alternative_receiver_phone_number'] = $this->_submitValues['alternative_receiver_phone_number'];

--- a/templates/CRM/Smsapi/Form/CivirulesAction.tpl
+++ b/templates/CRM/Smsapi/Form/CivirulesAction.tpl
@@ -1,5 +1,10 @@
 <h3>{$ruleActionHeader}</h3>
 <div class="crm-block crm-form-block crm-civirule-rule_action-block-sms-send">
+  <div class="help-block" id="help">
+    {ts}<p>If your rule is triggered by a user who is not logged in (e.g. when a contribution is made through a public page, or when an inbound SMS arrives), you must set the Message Sender below.</p>
+    <p>If your rule is triggered by a logged in user, you may optionally set the message sender; if you do not, the logged in user will be the sender.</p>
+    {/ts}
+  </div>
   <div class="crm-section">
     <div class="label">{$form.provider_id.label}</div>
     <div class="content">{$form.provider_id.html}</div>
@@ -8,6 +13,11 @@
   <div class="crm-section">
     <div class="label">{$form.template_id.label}</div>
     <div class="content">{$form.template_id.html}</div>
+    <div class="clear"></div>
+  </div>
+  <div class="crm-section">
+    <div class="label">{$form.from_contact_id.label}</div>
+    <div class="content">{$form.from_contact_id.html}</div>
     <div class="clear"></div>
   </div>
   <div class="crm-section">


### PR DESCRIPTION
Currently, any Civirule that uses "Send SMS" that is triggered by an anonymous user will fail.  @jaapjansma seems aware of this, based on the conversation in #5.

This fixes the issue by allowing an optional sender to be set.  If an optional sender is set, that contact is considered the sender of the SMS.